### PR TITLE
ReflectionParameter: try to get the correct default value for constants

### DIFF
--- a/src/Reflection/ReflectionParameter.php
+++ b/src/Reflection/ReflectionParameter.php
@@ -194,7 +194,10 @@ class ReflectionParameter
             && ! in_array(strtolower($defaultValueNode->name->parts[0]), ['true', 'false', 'null'], true)) {
             $this->isDefaultValueConstant   = true;
             $this->defaultValueConstantName = $defaultValueNode->name->parts[0];
-            $this->defaultValue             = null;
+            $this->defaultValue             = (new CompileNodeToValue())->__invoke(
+                $defaultValueNode,
+                new CompilerContext($this->reflector, null, null, null, null)
+            );
 
             return;
         }

--- a/test/unit/Reflection/ReflectionParameterTest.php
+++ b/test/unit/Reflection/ReflectionParameterTest.php
@@ -85,6 +85,16 @@ class ReflectionParameterTest extends TestCase
         self::assertSame('a', $parameterInfo->getName());
     }
 
+    public function testParamWithConstant(): void
+    {
+        $parameterInfo = ReflectionParameter::createFromClosure(static function (int $sort = SORT_ASC): void {
+        }, 'sort');
+
+        self::assertInstanceOf(ReflectionParameter::class, $parameterInfo);
+        self::assertSame(false, $parameterInfo->allowsNull());
+        self::assertSame(4, $parameterInfo->getDefaultValue());
+    }
+
     public function testCreateFromSpecWithArray() : void
     {
         $parameterInfo = ReflectionParameter::createFromSpec([SplDoublyLinkedList::class, 'add'], 'index');


### PR DESCRIPTION
Hi, I use your fork for a wrapper library (https://github.com/voku/Simple-PHP-Code-Parser) around PHP-Parser, phpDocumentor but I get wrong results for constants in parameters:

For example, this function ```function foo(int $case = \CASE_LOWER);```, ReflectionParameter->allowsNull() for ```$case```will currently return ```true``` but it should be ```false```, so here is a fix.

But now I see ```Roave\BetterReflection\NodeCompiler\Exception\UnableToCompileNode : Could not locate constant "SOME_DEFINED_VALUE" while evaluating expression in unknown context``` in a different test. :-/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ondrejmirtes/betterreflection/3)
<!-- Reviewable:end -->
