### PR TITLE
FindReturnType: fix

### DIFF
--- a/src/TypesFinder/FindParameterType.php
+++ b/src/TypesFinder/FindParameterType.php
@@ -48,20 +48,25 @@ class FindParameterType
 
         $context = $this->makeContext->__invoke($namespace);
 
-        /** @var Param[] $paramTags */
         $paramTags = $this
             ->docBlockFactory
             ->create($docComment, $context)
             ->getTagsByName('param');
 
         foreach ($paramTags as $paramTag) {
+            if (! $paramTag instanceof Param) {
+                continue;
+            }
+
             if ($node->var instanceof Error) {
                 throw new LogicException('PhpParser left an "Error" node in the parameters AST, this should NOT happen');
             }
 
-            if ($paramTag->getVariableName() === $node->var->name) {
-                return $this->resolveTypes->__invoke(explode('|', (string) $paramTag->getType()), $context);
+            if ($paramTag->getVariableName() !== $node->var->name) {
+                continue;
             }
+
+            return $this->resolveTypes->__invoke(explode('|', (string) $paramTag->getType()), $context);
         }
 
         return [];

--- a/src/TypesFinder/FindPropertyType.php
+++ b/src/TypesFinder/FindPropertyType.php
@@ -46,13 +46,19 @@ class FindPropertyType
         }
 
         $context = $this->makeContext->__invoke($namespace);
-        /** @var Var_[] $varTags */
-        $varTags = $this->docBlockFactory->create($docComment, $context)->getTagsByName('var');
+
+        $varTags = $this->docBlockFactory
+            ->create($docComment, $context)
+            ->getTagsByName('var');
 
         return array_merge(
             [],
-            ...array_map(function (Var_ $varTag) use ($context) {
-                return $this->resolveTypes->__invoke(explode('|', (string) $varTag->getType()), $context);
+            ...array_map(function ($varTag) use ($context) {
+                if ($varTag instanceof Var_) {
+                    return $this->resolveTypes->__invoke(explode('|', (string) $varTag->getType()), $context);
+                }
+
+                return [];
             }, $varTags)
         );
     }

--- a/src/TypesFinder/FindReturnType.php
+++ b/src/TypesFinder/FindReturnType.php
@@ -45,13 +45,16 @@ class FindReturnType
 
         $context = $this->makeContext->__invoke($namespace);
 
-        /** @var Return_[] $returnTags */
         $returnTags = $this
             ->docBlockFactory
             ->create($docComment, $context)
             ->getTagsByName('return');
 
         foreach ($returnTags as $returnTag) {
+            if (! $returnTag instanceof Return_) {
+                continue;
+            }
+
             return $this->resolveTypes->__invoke(explode('|', (string) $returnTag->getType()), $context);
         }
 

--- a/test/unit/TypesFinder/FindParameterTypeTest.php
+++ b/test/unit/TypesFinder/FindParameterTypeTest.php
@@ -37,6 +37,7 @@ class FindParameterTypeTest extends TestCase
             ['@param int|string $foo', 'foo', [Types\Integer::class, Types\String_::class]],
             ['@param array $foo', 'foo', [Types\Array_::class]],
             ['@param \stdClass $foo', 'foo', [Types\Object_::class]],
+            ['@param array{foo: string|int} $foo', 'foo', []],
             ['@param int|int[]|int[][] $foo', 'foo', [Types\Integer::class, Types\Array_::class, Types\Array_::class]],
             ['', 'foo', []],
             ['@param ?string $foo', 'foo', [Types\Nullable::class]],

--- a/test/unit/TypesFinder/FindPropertyTypeTest.php
+++ b/test/unit/TypesFinder/FindPropertyTypeTest.php
@@ -33,6 +33,7 @@ class FindPropertyTypeTest extends TestCase
         return [
             ['@var int|string $foo', [Types\Integer::class, Types\String_::class]],
             ['@var array $foo', [Types\Array_::class]],
+            ['@var array{foo: string|int} $foo', []],
             ['@var \stdClass $foo', [Types\Object_::class]],
             ['@var int|int[]|int[][] $foo', [Types\Integer::class, Types\Array_::class, Types\Array_::class]],
             ['', []],

--- a/test/unit/TypesFinder/FindReturnTypeTest.php
+++ b/test/unit/TypesFinder/FindReturnTypeTest.php
@@ -32,6 +32,7 @@ class FindReturnTypeTest extends TestCase
         return [
             ['@return int|string', [Types\Integer::class, Types\String_::class]],
             ['@return array', [Types\Array_::class]],
+            ['@return array{foo: string|int}', []],
             ['@return \stdClass', [Types\Object_::class]],
             ['@return int|int[]|int[][]', [Types\Integer::class, Types\Array_::class, Types\Array_::class]],
             ['@return int A comment about the return type', [Types\Integer::class]],


### PR DESCRIPTION
-> Call to undefined method phpDocumentor\Reflection\DocBlock\Tags\InvalidTag::getType()

ref:
- https://github.com/phpDocumentor/ReflectionDocBlock/pull/260
- https://github.com/Roave/BetterReflection/pull/700

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ondrejmirtes/betterreflection/6)
<!-- Reviewable:end -->
