### PR TITLE
Implement PHP Version dependent deprecations for constants

### DIFF
--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -665,6 +665,9 @@ final class PhpStormStubsSourceStubber implements SourceStubber
     private function addDeprecatedDocComment(Node\Stmt\ClassLike|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Stmt\Function_|Node\Stmt\Const_ $node): void
     {
         if ($node instanceof Node\Stmt\Const_) {
+            if (!$this->isDeprecatedByPhpDocInPhpVersion($node)) {
+                $this->removeAnnotationFromDocComment($node, 'deprecated');
+            }
             return;
         }
 
@@ -710,6 +713,23 @@ final class PhpStormStubsSourceStubber implements SourceStubber
         return in_array($extension, self::CORE_EXTENSIONS, true);
     }
 
+    private function isDeprecatedByPhpDocInPhpVersion(Node\Stmt\Const_ $node): bool
+    {
+        $docComment = $node->getDocComment();
+        if ($docComment === null) {
+            return false;
+        }
+
+        if (preg_match('#@deprecated (\d+\.\d+(?:\.\d+)?)$#m', $docComment, $matches) === 1) {
+            $version = $matches[1];
+
+            if (version_compare($this->phpVersion, $version, '>=')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
     private function isDeprecatedInPhpVersion(Node\Stmt\ClassLike|Node\Stmt\ClassConst|Node\Stmt\Property|Node\Stmt\ClassMethod|Node\Stmt\Function_ $node): bool
     {
         $deprecatedAttribute = $this->getNodeAttribute($node, 'JetBrains\PhpStorm\Deprecated');

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -479,6 +479,32 @@ class PhpStormStubsSourceStubberTest extends TestCase
         self::assertSame('Core', $stubData->getExtensionName());
     }
 
+    public function testStubForConstantThatIsDeprecated(): void
+    {
+        $stubData = $this->sourceStubber->generateConstantStub('FILTER_SANITIZE_STRING');
+
+        self::assertInstanceOf(StubData::class, $stubData);
+
+        self::assertStringMatchesFormat(
+            "%Adefine('FILTER_SANITIZE_STRING',%w%d);",
+            $stubData->getStub(),
+        );
+
+        // the constant is deprecated as of PHP 8.1
+        if (PHP_VERSION_ID >= 80100) {
+            self::assertStringContainsString(
+                "@deprecated 8.1",
+                $stubData->getStub(),
+            );
+        } else {
+            self::assertStringNotContainsString(
+                "@deprecated 8.1",
+                $stubData->getStub(),
+            );
+        }
+        self::assertSame('filter', $stubData->getExtensionName());
+    }
+
     public function testNoStubForConstantThatDoesNotExist(): void
     {
         self::assertNull($this->sourceStubber->generateConstantStub('SOME_CONSTANT'));


### PR DESCRIPTION
as discussed in https://github.com/phpstan/phpstan-deprecation-rules/pull/112#discussion_r1510222468 with this PR we strip the `@deprecated` phpdoc tag on constant definitions, in case the current php version does not match the declared min version.

motivation: report deprecation errors for constants only when the phpversion matches the `@deprecated $version`  we find in the jetbrains/phpstorm-stubs

example: https://github.com/JetBrains/phpstorm-stubs/blob/9608c953230b08f07b703ecfe459cc58d5421437/filter/filter.php#L478