### PR TITLE
ExprCacheHelper: Reduce PHPParser instantiation

### DIFF
--- a/src/BetterReflection.php
+++ b/src/BetterReflection.php
@@ -40,8 +40,6 @@ final class BetterReflection
 
     private Parser|null $phpParser = null;
 
-    private Parser|null $originalPhpParser = null;
-
     private AstLocator|null $astLocator = null;
 
     private FindReflectionOnLine|null $findReflectionOnLine = null;
@@ -108,12 +106,6 @@ final class BetterReflection
     {
         return $this->phpParser
             ?? $this->phpParser = (new ParserFactory())->createForNewestSupportedVersion();
-    }
-
-    public function originalPhpParser(): Parser
-    {
-        return $this->originalPhpParser
-            ?? $this->originalPhpParser = (new ParserFactory())->createForNewestSupportedVersion();
     }
 
     public function astLocator(): AstLocator

--- a/src/Reflection/ExprCacheHelper.php
+++ b/src/Reflection/ExprCacheHelper.php
@@ -9,13 +9,14 @@ use Roave\BetterReflection\BetterReflection;
 
 final class ExprCacheHelper
 {
+    private static ?BetterReflection $betterReflection = null;
 
     /**
-     * @return array<string, mixed
+     * @return array<string, mixed>
      */
     public static function export(Expr $expr): array
     {
-        $br = new BetterReflection();
+        $br = self::$betterReflection ??= new BetterReflection();
 
         $attributes = [];
         foreach (['startLine', 'endLine', 'startTokenPos', 'startFilePos', 'endTokenPos', 'endFilePos'] as $key) {
@@ -33,8 +34,9 @@ final class ExprCacheHelper
         $code = $data['code'];
         $attributes = $data['attributes'];
 
-        $br = new BetterReflection();
-        $expr = $br->originalPhpParser()->parse('<?php ' . $code . ';')[0]->expr;
+        $br = self::$betterReflection ??= new BetterReflection();
+        // cached parser implementations might re-use nodes. clone so we don't mix up attributes.
+        $expr = clone $br->phpParser()->parse('<?php ' . $code . ';')[0]->expr;
         foreach ($attributes as $key => $value) {
             $expr->setAttribute($key, $value);
         }


### PR DESCRIPTION
ReflectionConstant/ReflectionParameter->importFromCache() is expensive.
it is dominated by PHPParser overhead


<img width="360" height="715" alt="Image" src="https://github.com/user-attachments/assets/d5b6e2e6-281d-408b-a10e-f39ca35e2e6a" />

looks like the parser instantiation happens multiple times

----

before/after PR when running PHPStan on a single file change

<img width="1185" height="823" alt="grafik" src="https://github.com/user-attachments/assets/156de9c9-e60a-43cb-9aba-3d9e8ef5b2a6" />

----

covered by test in https://github.com/phpstan/phpstan-src/pull/5023