### PR TITLE
Compile closures and first-class callables in constant expressions (PHP 8.5)

### DIFF
--- a/src/NodeCompiler/CompileNodeToValue.php
+++ b/src/NodeCompiler/CompileNodeToValue.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace PHPStan\BetterReflection\NodeCompiler;
 
 use Attribute;
+use Closure;
 use PhpParser\ConstExprEvaluator;
 use PhpParser\Node;
+use PhpParser\PrettyPrinter\Standard as PrettyPrinter;
 use PHPStan\BetterReflection\Reflection\ReflectionClass;
 use PHPStan\BetterReflection\Reflection\ReflectionClassConstant;
 use PHPStan\BetterReflection\Reflection\ReflectionEnum;
@@ -23,6 +25,8 @@ use function explode;
 use function in_array;
 use function is_file;
 use function sprintf;
+
+use const PHP_VERSION_ID;
 
 /** @internal */
 class CompileNodeToValue
@@ -173,6 +177,18 @@ class CompileNodeToValue
                 return (object) $this($node->expr, $context)->value;
             }
 
+            if ($node instanceof Node\Expr\Closure) {
+                return $this->compileClosureDeclaration($node, $context);
+            }
+
+            if (
+                ($node instanceof Node\Expr\FuncCall || $node instanceof Node\Expr\StaticCall)
+                && $node->isFirstClassCallable()
+                && PHP_VERSION_ID >= 80100 // the syntax cannot be eval'd on older runtimes
+            ) {
+                return $this->compileClosureDeclaration($node, $context);
+            }
+
             throw Exception\UnableToCompileNode::forUnRecognizedExpressionInContext($node, $context);
         });
 
@@ -217,6 +233,59 @@ class CompileNodeToValue
             default:
                 throw Exception\UnableToCompileNode::becauseOfInvalidEnumCasePropertyFetch($context, $class, $node);
         }
+    }
+
+    /**
+     * Compile a closure or a first-class callable declared in a constant expression (PHP 8.5+)
+     * into a real Closure, like native reflection does.
+     *
+     * The language guarantees such closures are static and capture no variables,
+     * so evaluating the declaration itself executes no user code.
+     *
+     * @param Node\Expr\Closure|Node\Expr\FuncCall|Node\Expr\StaticCall $node
+     */
+    private function compileClosureDeclaration(Node\Expr $node, CompilerContext $context): Closure
+    {
+        if ($node instanceof Node\Expr\StaticCall && $node->class instanceof Node\Name) {
+            $calleeClassName = $this->resolveClassName($node->class->toString(), $context);
+
+            if (! class_exists($calleeClassName)) {
+                throw Exception\UnableToCompileNode::becauseOfClassCannotBeLoaded($context, $node, $calleeClassName);
+            }
+
+            $node        = clone $node;
+            $node->class = new Node\Name\FullyQualified($calleeClassName);
+        }
+
+        $code = (new PrettyPrinter())->prettyPrintExpr($node);
+
+        $namespace = $context->getNamespace();
+
+        // The namespace wrapper keeps the fallback to global scope for unqualified function calls
+        $code = $namespace !== null && $namespace !== ''
+            ? sprintf('namespace %s; return %s;', $namespace, $code)
+            : sprintf('return %s;', $code);
+
+        try {
+            $closure = eval($code);
+        } catch (\Throwable $e) {
+            // e.g. a syntax not supported by the current runtime
+            throw Exception\UnableToCompileNode::forUnRecognizedExpressionInContext($node, $context);
+        }
+
+        assert($closure instanceof Closure);
+
+        $contextClass     = $context->getClass();
+        $contextClassName = $contextClass !== null ? $contextClass->getName() : null;
+
+        // Bind the class scope like native reflection does
+        if ($contextClassName !== null && class_exists($contextClassName)) {
+            $boundClosure = Closure::bind($closure, null, $contextClassName);
+
+            return $boundClosure ?? $closure;
+        }
+
+        return $closure;
     }
 
     private function resolveConstantName(Node\Expr\ConstFetch $constNode, CompilerContext $context): string

--- a/test/unit/Fixture/AttributesWithClosures.php
+++ b/test/unit/Fixture/AttributesWithClosures.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Roave\BetterReflectionTest\Fixture;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_ALL | Attribute::IS_REPEATABLE)]
+class AttrWithCallback
+{
+    public function __construct(public mixed $callback)
+    {
+    }
+}
+
+#[AttrWithCallback(static function (int $value): int {
+    return $value * 2;
+})]
+#[AttrWithCallback(callback: static function (string $value): string {
+    return strtolower($value);
+})]
+#[AttrWithCallback(strtoupper(...))]
+class ClassWithClosuresInAttributes
+{
+    public function methodWithClosureInParameterDefault(
+        mixed $callback = static function (): string {
+            return 'default';
+        },
+    ): void {
+    }
+}
+
+#[AttrWithCallback(static function (): string {
+    return self::secret();
+})]
+class ClassWithScopedClosureInAttribute
+{
+    private static function secret(): string
+    {
+        return 'scoped';
+    }
+}

--- a/test/unit/NodeCompiler/CompileNodeToValueTest.php
+++ b/test/unit/NodeCompiler/CompileNodeToValueTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Roave\BetterReflectionTest\NodeCompiler;
 
 use ArrayObject;
+use Closure;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ConstFetch;
 use PhpParser\Node\Expr\Yield_;
@@ -1050,6 +1051,18 @@ PHP;
         $getHookParameterAttribute = $getHookParameter->getAttributes()[0];
 
         self::assertSame($expectedValue, $getHookParameterAttribute->getArguments()[0]);
+    }
+
+    public function testClosureInParameterDefault(): void
+    {
+        $reflector = new DefaultReflector(new SingleFileSourceLocator(self::realPath(__DIR__ . '/../Fixture/AttributesWithClosures.php'), $this->astLocator));
+        $class     = $reflector->reflectClass('Roave\BetterReflectionTest\Fixture\ClassWithClosuresInAttributes');
+        $parameter = $class->getMethod('methodWithClosureInParameterDefault')->getParameter('callback');
+
+        $default = $parameter->getDefaultValue();
+
+        self::assertInstanceOf(Closure::class, $default);
+        self::assertSame('default', $default());
     }
 
     public function testObjectCast(): void

--- a/test/unit/Reflection/ReflectionAttributeTest.php
+++ b/test/unit/Reflection/ReflectionAttributeTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Roave\BetterReflectionTest\Reflection;
 
 use Attribute;
+use Closure;
 use PhpParser\Node;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhp;
 use PHPUnit\Framework\TestCase;
 use PHPStan\BetterReflection\Reflection\ReflectionAttribute;
 use PHPStan\BetterReflection\Reflection\ReflectionClass;
@@ -18,6 +20,7 @@ use PHPStan\BetterReflection\SourceLocator\Type\SingleFileSourceLocator;
 use Roave\BetterReflectionTest\BetterReflectionSingleton;
 use Roave\BetterReflectionTest\Fixture\AnotherAttr;
 use Roave\BetterReflectionTest\Fixture\Attr;
+use Roave\BetterReflectionTest\Fixture\AttrWithCallback;
 use Roave\BetterReflectionTest\Fixture\ClassWithAttributes;
 use Roave\BetterReflectionTest\Fixture\ClassWithAttributesWithArguments;
 use Roave\BetterReflectionTest\Fixture\ClassWithRepeatedAttributes;
@@ -121,6 +124,43 @@ class ReflectionAttributeTest extends TestCase
         self::assertCount(count($expectedArguments), $attributes[0]->getArgumentsExpressions());
         self::assertContainsOnlyInstancesOf(Node\Expr::class, $attributes[0]->getArgumentsExpressions());
         self::assertSame($expectedArguments, $attributes[0]->getArguments());
+    }
+
+    public function testGetArgumentsWithClosures(): void
+    {
+        $reflector       = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/AttributesWithClosures.php', $this->astLocator));
+        $classReflection = $reflector->reflectClass('Roave\BetterReflectionTest\Fixture\ClassWithClosuresInAttributes');
+        $attributes      = $classReflection->getAttributesByName(AttrWithCallback::class);
+
+        self::assertCount(3, $attributes);
+
+        $closure = $attributes[0]->getArguments()[0];
+        self::assertInstanceOf(Closure::class, $closure);
+        self::assertSame(42, $closure(21));
+
+        $namedArgumentClosure = $attributes[1]->getArguments()['callback'];
+        self::assertInstanceOf(Closure::class, $namedArgumentClosure);
+        self::assertSame('abc', $namedArgumentClosure('ABC'));
+
+        $firstClassCallable = $attributes[2]->getArguments()[0];
+        self::assertInstanceOf(Closure::class, $firstClassCallable);
+        self::assertSame('ABC', $firstClassCallable('abc'));
+    }
+
+    #[RequiresPhp('>= 8.5.0')]
+    public function testGetArgumentsWithClosureBoundToDeclaringClass(): void
+    {
+        require_once __DIR__ . '/../Fixture/AttributesWithClosures.php';
+
+        $reflector       = new DefaultReflector(new SingleFileSourceLocator(__DIR__ . '/../Fixture/AttributesWithClosures.php', $this->astLocator));
+        $classReflection = $reflector->reflectClass('Roave\BetterReflectionTest\Fixture\ClassWithScopedClosureInAttribute');
+        $attributes      = $classReflection->getAttributesByName(AttrWithCallback::class);
+
+        self::assertCount(1, $attributes);
+
+        $closure = $attributes[0]->getArguments()[0];
+        self::assertInstanceOf(Closure::class, $closure);
+        self::assertSame('scoped', $closure());
     }
 
     public function testGetTargetWithClass(): void


### PR DESCRIPTION
## Problem

PHP 8.5 allows static closures and first-class callables in constant expressions ([RFC](https://wiki.php.net/rfc/closures_in_const_expr)), for example in attribute arguments. `CompileNodeToValue` does not recognize `Expr\Closure` and first-class-callable nodes, so `ReflectionAttribute::getArguments()` throws:

```
Unable to compile expression in class ...: unrecognized node type PhpParser\Node\Expr\Closure
```

For PHPStan users this surfaces as a non-ignorable `phpstan.reflection` error whenever an extension calls `getArguments()` on such an attribute. Real-world report: shipmonk-rnd/dead-code-detector#404 (mitigated downstream in shipmonk-rnd/dead-code-detector#405, but every other extension stays exposed).

## Why here and not Roave

The same fix was proposed upstream in Roave/BetterReflection#1574 and was declined: producing the value can trigger autoloading (first-class callables) and compiles reflected source via `eval`, which conflicts with Roave's no-autoloading invariant. This fork already crossed that line deliberately — `compileNew()` autoloads (`class_exists($className)`) and executes user constructors (`new $className(...$arguments)`) — so the change is consistent with the fork's semantics and fixes the actual PHPStan use case.

## Fix

Compile these nodes into real `Closure` instances, like native reflection does:

- Pretty-print the node and `eval()` it inside the declaring namespace. Const-expr closures are guaranteed **static with no captured variables**, so evaluating the declaration executes no user code (the body runs only if the caller invokes it).
- Bind the declaring class scope (`Closure::bind`), so `self::` works inside the body like at runtime.
- Resolve `self`/`parent`/`static` in first-class callables and require the callee class to be loadable (same rule and exception as `compileNew()`).
- Guard first-class callables with `PHP_VERSION_ID >= 80100` and wrap `eval` in a try/catch, so runtimes older than the analyzed syntax keep throwing `UnableToCompileNode` instead of a fatal.

Unlike the Roave PR, no return-type widening is needed: this fork's `getDefaultValue()` methods are already untyped with `@return mixed`.

Note: arrow functions need no handling — PHP 8.5 rejects them in constant expressions.

## Tests

New tests in `ReflectionAttributeTest` and `CompileNodeToValueTest` fail on current 6.70.x with the exact error above and pass with this change. The scope-binding test requires PHP 8.5 (the fixture must be natively loadable); the others run on any supported runtime, since only the analyzed code needs 8.5 syntax. Full unit suite: no new failures compared to the 6.70.x baseline on my machine.

Co-Authored-By: Claude Code