### PR TITLE
`LanguageLevelTypeAware` pseudo-types should be turned into phpdoc-type

### DIFF
--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -61,8 +61,8 @@ use function ltrim;
 use function preg_match;
 use function preg_replace;
 use function sprintf;
+use function str_contains;
 use function str_replace;
-use function strpos;
 use function strtolower;
 use function usort;
 
@@ -980,7 +980,7 @@ final class PhpStormStubsSourceStubber implements SourceStubber
     private function normalizeType(string $type): Name|Identifier|ComplexType|null
     {
         // There are some invalid types in stubs, eg. `string[]|string|null`
-        if (strpos($type, '[') !== false) {
+        if (str_contains($type, '[')) {
             return null;
         }
 

--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -741,7 +741,11 @@ final class PhpStormStubsSourceStubber implements SourceStubber
         $function->params = $parameters;
     }
 
-    private function getStmtType(Function_|ClassMethod|Property|Param $node): Name|Identifier|ComplexType|null
+    /**
+     * @param \PhpParser\Node\Stmt\Function_|\PhpParser\Node\Stmt\ClassMethod|\PhpParser\Node\Stmt\Property|\PhpParser\Node\Param $node
+     * @return \PhpParser\Node\Name|\PhpParser\Node\Identifier|\PhpParser\Node\ComplexType|null
+     */
+    private function getStmtType($node)
     {
         $type = $this->getRawStmtType($node);
 
@@ -752,7 +756,11 @@ final class PhpStormStubsSourceStubber implements SourceStubber
         return $this->normalizeType($type);
     }
 
-    private function getRawStmtType(Function_|ClassMethod|Property|Param $node): string|null
+    /**
+     * @param \PhpParser\Node\Stmt\Function_|\PhpParser\Node\Stmt\ClassMethod|\PhpParser\Node\Stmt\Property|\PhpParser\Node\Param $node
+     * @return string|null
+     */
+    private function getRawStmtType($node)
     {
         $languageLevelTypeAwareAttribute = $this->getNodeAttribute($node, 'JetBrains\PhpStorm\Internal\LanguageLevelTypeAware');
 
@@ -977,10 +985,13 @@ final class PhpStormStubsSourceStubber implements SourceStubber
         return $parts[0] * 10000 + $parts[1] * 100 + ($parts[2] ?? $defaultPatch);
     }
 
-    private function normalizeType(string $type): Name|Identifier|ComplexType|null
+    /**
+     * @return \PhpParser\Node\Name|\PhpParser\Node\Identifier|\PhpParser\Node\ComplexType|null
+     */
+    private function normalizeType(string $type)
     {
         // There are some invalid types in stubs, eg. `string[]|string|null`
-        if (str_contains($type, '[')) {
+        if (strpos($type, '[') !== false) {
             return null;
         }
 

--- a/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
+++ b/src/SourceLocator/SourceStubber/PhpStormStubsSourceStubber.php
@@ -18,6 +18,17 @@ use PhpParser\BuilderFactory;
 use PhpParser\BuilderHelpers;
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
+use PhpParser\Node\ComplexType;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Param;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\ClassLike;
+use PhpParser\Node\Stmt\ClassMethod;
+use PhpParser\Node\Stmt\Const_;
+use PhpParser\Node\Stmt\EnumCase;
+use PhpParser\Node\Stmt\Function_;
+use PhpParser\Node\Stmt\Property;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\NameResolver;
 use PhpParser\Parser;
@@ -45,11 +56,13 @@ use function explode;
 use function file_get_contents;
 use function in_array;
 use function is_dir;
+use function is_string;
+use function ltrim;
 use function preg_match;
 use function preg_replace;
 use function sprintf;
-use function str_contains;
 use function str_replace;
+use function strpos;
 use function strtolower;
 use function usort;
 
@@ -683,6 +696,15 @@ final class PhpStormStubsSourceStubber implements SourceStubber
             return;
         }
 
+        $rawType = $this->getRawStmtType($function);
+
+        if ($rawType !== null && self::isResourcePseudoType($rawType)) {
+            $this->addTagToDocComment($function, sprintf('return %s', $rawType));
+            $function->returnType = null;
+
+            return;
+        }
+
         $type = $this->getStmtType($function);
 
         if ($type === null) {
@@ -703,13 +725,34 @@ final class PhpStormStubsSourceStubber implements SourceStubber
 
             $this->modifyStmtTypeByPhpVersion($parameterNode);
 
+            $rawType = $this->getRawStmtType($parameterNode);
+
+            if ($rawType !== null && self::isResourcePseudoType($rawType)) {
+                assert($parameterNode->var instanceof Node\Expr\Variable);
+                assert(is_string($parameterNode->var->name));
+
+                $this->addTagToDocComment($function, sprintf('param %s $%s', $rawType, $parameterNode->var->name));
+                $parameterNode->type = null;
+            }
+
             $parameters[] = $parameterNode;
         }
 
         $function->params = $parameters;
     }
 
-    private function getStmtType(Node\Stmt\Function_|Node\Stmt\ClassMethod|Node\Stmt\Property|Node\Param $node): Node\Name|Node\Identifier|Node\ComplexType|null
+    private function getStmtType(Function_|ClassMethod|Property|Param $node): Name|Identifier|ComplexType|null
+    {
+        $type = $this->getRawStmtType($node);
+
+        if ($type === null) {
+            return null;
+        }
+
+        return $this->normalizeType($type);
+    }
+
+    private function getRawStmtType(Function_|ClassMethod|Property|Param $node): string|null
     {
         $languageLevelTypeAwareAttribute = $this->getNodeAttribute($node, 'JetBrains\PhpStorm\Internal\LanguageLevelTypeAware');
 
@@ -732,13 +775,13 @@ final class PhpStormStubsSourceStubber implements SourceStubber
                 continue;
             }
 
-            return $this->normalizeType($type->value->value);
+            return $type->value->value;
         }
 
         assert($languageLevelTypeAwareAttribute->args[1]->value instanceof Node\Scalar\String_);
 
         return $languageLevelTypeAwareAttribute->args[1]->value->value !== ''
-            ? $this->normalizeType($languageLevelTypeAwareAttribute->args[1]->value->value)
+            ? $languageLevelTypeAwareAttribute->args[1]->value->value
             : null;
     }
 
@@ -934,15 +977,37 @@ final class PhpStormStubsSourceStubber implements SourceStubber
         return $parts[0] * 10000 + $parts[1] * 100 + ($parts[2] ?? $defaultPatch);
     }
 
-    private function normalizeType(string $type): Node\Name|Node\Identifier|Node\ComplexType|null
+    private function normalizeType(string $type): Name|Identifier|ComplexType|null
     {
         // There are some invalid types in stubs, eg. `string[]|string|null`
-        if (str_contains($type, '[')) {
+        if (strpos($type, '[') !== false) {
+            return null;
+        }
+
+        if (self::isResourcePseudoType($type)) {
             return null;
         }
 
         /** @psalm-suppress InternalClass, InternalMethod */
         return BuilderHelpers::normalizeType($type);
+    }
+
+    /**
+     * `resource` is a pseudo-type: PHP has no such native type, and a `resource`
+     * typehint in source code is read back as a class name. The stubs use it in
+     * `#[LanguageLevelTypeAware]` to describe pre-PHP 8 signatures, so it must never
+     * become a native type - it is moved into the PHPDoc instead, where `resource`
+     * is a well-known type.
+     */
+    private static function isResourcePseudoType(string $type): bool
+    {
+        return in_array('resource', explode('|', ltrim($type, '?')), true);
+    }
+
+    private function addTagToDocComment(ClassLike|ClassConst|Property|ClassMethod|Function_|Const_|EnumCase $node, string $tag): void
+    {
+        $this->removeAnnotationFromDocComment($node, $tag);
+        $this->addAnnotationToDocComment($node, $tag);
     }
 
     private function getStubsDirectory(): string

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -1065,7 +1065,7 @@ class PhpStormStubsSourceStubberTest extends TestCase
         }
     }
 
-    public function testLanguageLevelTypeAwareDefaultResourceDoesNotBecomeNativeResourceType(): void
+    public function testLanguageLevelTypeAwareDefaultResourceDoesNotBecomeNativeResourceReturnType(): void
     {
         $sourceStubber = new PhpStormStubsSourceStubber($this->phpParser, 70400);
         $reflector     = new DefaultReflector(new PhpInternalSourceLocator($this->astLocator, $sourceStubber));
@@ -1074,6 +1074,20 @@ class PhpStormStubsSourceStubberTest extends TestCase
 
         self::assertStringContainsString('@return resource|false', $function->getDocComment() ?? '');
         self::assertNull($function->getReturnType());
+    }
+
+    public function testLanguageLevelTypeAwareDefaultResourceDoesNotBecomeNativeResourceParameterType(): void
+    {
+        $sourceStubber = new PhpStormStubsSourceStubber($this->phpParser, 70400);
+        $reflector     = new DefaultReflector(new PhpInternalSourceLocator($this->astLocator, $sourceStubber));
+
+        $function  = $reflector->reflectFunction('dba_exists');
+        $parameter = $function->getParameter('dba');
+
+        self::assertStringContainsString('@param resource', $function->getDocComment() ?? '');
+
+        self::assertInstanceOf(ReflectionParameter::class, $parameter);
+        self::assertNull($parameter->getType());
     }
 
     /** @return list<array{0: string, 1: int, 2: bool}> */

--- a/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
+++ b/test/unit/SourceLocator/SourceStubber/PhpStormStubsSourceStubberTest.php
@@ -1065,6 +1065,17 @@ class PhpStormStubsSourceStubberTest extends TestCase
         }
     }
 
+    public function testLanguageLevelTypeAwareDefaultResourceDoesNotBecomeNativeResourceType(): void
+    {
+        $sourceStubber = new PhpStormStubsSourceStubber($this->phpParser, 70400);
+        $reflector     = new DefaultReflector(new PhpInternalSourceLocator($this->astLocator, $sourceStubber));
+
+        $function = $reflector->reflectFunction('finfo_open');
+
+        self::assertStringContainsString('@return resource|false', $function->getDocComment() ?? '');
+        self::assertNull($function->getReturnType());
+    }
+
     /** @return list<array{0: string, 1: int, 2: bool}> */
     public static function dataConstantInPhpVersion(): array
     {


### PR DESCRIPTION
backport https://github.com/Roave/BetterReflection/pull/1579

required to support the fix in https://github.com/phpstan/phpstan-src/pull/6378